### PR TITLE
Ghost download URL changed

### DIFF
--- a/update-ghost.sh
+++ b/update-ghost.sh
@@ -33,8 +33,8 @@ echo "your ghost-directory has been backed up.";
 
 export TMPDIR=`mktemp -d /tmp/XXXXXX`
 
-curl -L https://ghost.org/zip/ghost-$VERSION.zip -O
-unzip ghost-$VERSION.zip -d ghost-$VERSION
+curl -L https://github.com/TryGhost/Ghost/releases/download/$VERSION/Ghost-$VERSION.zip -O
+unzip Ghost-$VERSION.zip -d ghost-$VERSION
 
 rm -rf $GHOSTDIR/core
 mv ~/ghost-$VERSION/core $GHOSTDIR/core


### PR DESCRIPTION
The download URL is no longer valid (404-Message). Changed it to
https://github.com/TryGhost/Ghost/releases/download/$VERSION/Ghost-$VERS
ION.zip